### PR TITLE
Make package importable for go users

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"html/template"
 	"os"
 
+	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
 )
 
@@ -142,7 +143,7 @@ func setNexusCredentials(c *cli.Context) error {
 }
 
 func listImages(c *cli.Context) error {
-	r, err := NewRegistry()
+	r, err := registry.NewRegistry()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -159,7 +160,7 @@ func listImages(c *cli.Context) error {
 
 func listTagsByImage(c *cli.Context) error {
 	var imgName = c.String("name")
-	r, err := NewRegistry()
+	r, err := registry.NewRegistry()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -180,7 +181,7 @@ func listTagsByImage(c *cli.Context) error {
 func showImageInfo(c *cli.Context) error {
 	var imgName = c.String("name")
 	var tag = c.String("tag")
-	r, err := NewRegistry()
+	r, err := registry.NewRegistry()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -208,7 +209,7 @@ func deleteImage(c *cli.Context) error {
 		fmt.Fprintf(c.App.Writer, "You should specify the image name\n")
 		cli.ShowSubcommandHelp(c)
 	} else {
-		r, err := NewRegistry()
+		r, err := registry.NewRegistry()
 		if err != nil {
 			return cli.NewExitError(err.Error(), 1)
 		}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -1,4 +1,4 @@
-package main
+package registry
 
 import (
 	"encoding/json"


### PR DESCRIPTION
### Description
Hi, thanks for sharing your tool, it really saved me the other day when my registry was almost exploding 🔥 

As I found the tool really helpful I wanted to include its functionality in a tool to cleanup our dev deployments in Kubernetes with a tool based in go. Sadly I noticed it is not possible because most of the logic is in the `main` package.

### Changes proposed 
The change is pretty simple, move `registry.go` to its own `registry` package so it is possible to import it in other go projects.
