### PR TITLE
Hide passwords during input, Unescape before communicating with Nexus

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
+	"golang.org/x/crypto/ssh/terminal"
 )
 
 const (
@@ -111,7 +112,11 @@ func setNexusCredentials(c *cli.Context) error {
 	fmt.Print("Enter Nexus Username: ")
 	fmt.Scan(&username)
 	fmt.Print("Enter Nexus Password: ")
-	fmt.Scan(&password)
+	bytePassword, err := terminal.ReadPassword(0)
+	if err != nil {
+		return fmt.Errorf("Could not read password from terminal: %v", err)
+	}
+	password = string(bytePassword)
 
 	data := struct {
 		Host       string

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"syscall"
 
 	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
@@ -112,7 +113,7 @@ func setNexusCredentials(c *cli.Context) error {
 	fmt.Print("Enter Nexus Username: ")
 	fmt.Scan(&username)
 	fmt.Print("Enter Nexus Password: ")
-	bytePassword, err := terminal.ReadPassword(0)
+	bytePassword, err := terminal.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return fmt.Errorf("Could not read password from terminal: %v", err)
 	}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"html"
 	"net/http"
 	"os"
 
@@ -51,6 +52,7 @@ func NewRegistry() (Registry, error) {
 	if _, err := toml.DecodeFile(".credentials", &r); err != nil {
 		return r, err
 	}
+	r.Password = html.UnescapeString(r.Password)
 	return r, nil
 }
 


### PR DESCRIPTION
### Description
 Hi! I had some time and decided to contribute a little since we are finding your tool very useful. This PR  addresses two things:
- Passwords are not displayed during the `configure` input step
- Passwords are unescaped before sending them to Nexus. `html/template` that is used for storing the `.credentials` file escapes them automatically, unescaping them is needed.

Cheers!

### Related Issue
- Issue #6 

