### PR TITLE
Credentials refactoring (configuration step)

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,19 +2,10 @@ package main
 
 import (
 	"fmt"
-	"html/template"
 	"os"
 
 	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
-)
-
-const (
-	CREDENTIALS_TEMPLATES = `# Nexus Credentials
-nexus_host = "{{ .Host }}"
-nexus_username = "{{ .Username }}"
-nexus_password = "{{ .Password }}"
-nexus_repository = "{{ .Repository }}"`
 )
 
 func main() {
@@ -113,29 +104,15 @@ func setNexusCredentials(c *cli.Context) error {
 	fmt.Print("Enter Nexus Password: ")
 	fmt.Scan(&password)
 
-	data := struct {
-		Host       string
-		Username   string
-		Password   string
-		Repository string
-	}{
+	data := registry.Registry{
 		hostname,
 		username,
 		password,
 		repository,
 	}
 
-	tmpl, err := template.New(".credentials").Parse(CREDENTIALS_TEMPLATES)
-	if err != nil {
-		return cli.NewExitError(err.Error(), 1)
-	}
+	err := registry.SetupCredentials(data)
 
-	f, err := os.Create(".credentials")
-	if err != nil {
-		return cli.NewExitError(err.Error(), 1)
-	}
-
-	err = tmpl.Execute(f, data)
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}


### PR DESCRIPTION
*Thanks for this project. It's really cool.*

I'm using it to provide a docker image versions dropdown to be selected to deploy. But something I'm suffering is that I need to run `nexus-cli` from the specific path where I placed the `.credentials` file. 

So I'm creating this PR. I'm new to golang so let me know if it's good enough to merge. I'm also missing tests. Below are the points I did in this PR.

* Move `.credentials` file to `~/.nexus-cli/.credentials` path to enable the use of nexus-cli from all folders. 
* Move the entire logic of configuration step to registry package