### PR TITLE
Natural-sort tags, sorting test, minimal typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+.credentials
+.DS_Store

--- a/main.go
+++ b/main.go
@@ -168,6 +168,12 @@ func listTagsByImage(c *cli.Context) error {
 		cli.ShowSubcommandHelp(c)
 	}
 	tags, err := r.ListTagsByImage(imgName)
+
+	compareStringNumber := func(str1, str2 string) bool {
+		return extractNumberFromString(str1) < extractNumberFromString(str2)
+	}
+	Compare(compareStringNumber).Sort(tags)
+
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
 	}
@@ -219,6 +225,10 @@ func deleteImage(c *cli.Context) error {
 				cli.ShowSubcommandHelp(c)
 			} else {
 				tags, err := r.ListTagsByImage(imgName)
+				compareStringNumber := func(str1, str2 string) bool {
+					return extractNumberFromString(str1) < extractNumberFromString(str2)
+				}
+				Compare(compareStringNumber).Sort(tags)
 				if err != nil {
 					return cli.NewExitError(err.Error(), 1)
 				}

--- a/registry/registry.go
+++ b/registry/registry.go
@@ -4,13 +4,13 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/BurntSushi/toml"
 	"net/http"
 	"os"
-
-	"github.com/BurntSushi/toml"
 )
 
 const ACCEPT_HEADER = "application/vnd.docker.distribution.manifest.v2+json"
+const CREDENTIALS_FILE = ".credentials"
 
 type Registry struct {
 	Host       string `toml:"nexus_host"`
@@ -42,13 +42,13 @@ type LayerInfo struct {
 
 func NewRegistry() (Registry, error) {
 	r := Registry{}
-	if _, err := os.Stat(".credentials"); os.IsNotExist(err) {
-		return r, errors.New(".crendetials file not found\n")
+	if _, err := os.Stat(CREDENTIALS_FILE); os.IsNotExist(err) {
+		return r, errors.New(fmt.Sprintf("%s file not found\n", CREDENTIALS_FILE))
 	} else if err != nil {
 		return r, err
 	}
 
-	if _, err := toml.DecodeFile(".credentials", &r); err != nil {
+	if _, err := toml.DecodeFile(CREDENTIALS_FILE, &r); err != nil {
 		return r, err
 	}
 	return r, nil

--- a/sorter.go
+++ b/sorter.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"log"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+// Almost completely ripped off https://www.socketloop.com/tutorials/golang-natural-string-sorting-example
+
+type Compare func(str1, str2 string) bool
+
+func (cmp Compare) Sort(strs []string) {
+	strSort := &strSorter{
+		strs: strs,
+		cmp:  cmp,
+	}
+	sort.Sort(strSort)
+}
+
+type strSorter struct {
+	strs []string
+	cmp  func(str1, str2 string) bool
+}
+
+func extractNumberFromString(str string) (num int) {
+	strSlice := make([]string, 0)
+	for _, v := range str {
+		if unicode.IsDigit(v) {
+			strSlice = append(strSlice, string(v))
+		}
+	}
+
+	// If the tag was all non-digits, the strSlice would be empty (e.g., 'latest')
+	// therefore just throw it to the end (1 << 32 is maxint)
+	if len(strSlice) == 0 {
+		return 1 << 32
+	}
+
+	num, err := strconv.Atoi(strings.Join(strSlice, ""))
+	if err != nil {
+		log.Fatal(err)
+	}
+	return num
+}
+
+func (s *strSorter) Len() int { return len(s.strs) }
+
+func (s *strSorter) Swap(i, j int) { s.strs[i], s.strs[j] = s.strs[j], s.strs[i] }
+
+func (s *strSorter) Less(i, j int) bool { return s.cmp(s.strs[i], s.strs[j]) }

--- a/sorter_test.go
+++ b/sorter_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func Test_SortMixed(t *testing.T) {
+	tags := []string{"latest", "1.0.1"}
+
+	compareStringNumber := func(str1, str2 string) bool {
+		return extractNumberFromString(str1) < extractNumberFromString(str2)
+	}
+	Compare(compareStringNumber).Sort(tags)
+
+	if tags[0] != "1.0.1" && tags[1] != "latest" {
+		t.Errorf("ordering incorrect when checking mixed tags")
+	}
+}
+
+func Test_SortAllDigits(t *testing.T) {
+	tags := []string{"1.2.1", "1.0.1"}
+
+	compareStringNumber := func(str1, str2 string) bool {
+		return extractNumberFromString(str1) < extractNumberFromString(str2)
+	}
+	Compare(compareStringNumber).Sort(tags)
+
+	if tags[0] != "1.0.1" && tags[1] != "1.2.1" {
+		t.Errorf("ordering incorrect in all digits tags")
+	}
+}


### PR DESCRIPTION
### Description
Originally, the Docker Registry returns the tag names ordered as strings (e.g., 1.100.0, 1.2.0, 1.30.0, etc...)
It'd be great if the tags were "humanely ordered"; also known as, natural order.

### Related issues
#5 

### Changes proposed 
1. Implemented a sorter.go
2. Added a few minimal tests for it
3. Also fixed a few typos, and added a .gitignore file

### Screenshots
https://imgur.com/a/QoxZV
