### PR TITLE
Show total image size

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,9 @@ $ nexus-cli image delete -name mlabouardy/nginx -tag 1.2.0
 $ nexus-cli image delete -name mlabouardy/nginx -keep 4
 ```
 
+```
+$ nexus-cli image size -name mlabouardy/nginx
+```
 ## Tutorials
 
 * [Cleanup old Docker images from Nexus Repository](http://www.blog.labouardy.com/cleanup-old-docker-images-from-nexus-repository/)


### PR DESCRIPTION
### Description

This change is for displaying the total size of an image, including all tags. 

We have used this functionality in a script to determine which images consume the most disk space, and eventually to delete some or all tags using nexus-cli. 

### Related Issue

None

### Changes proposed 

Add a function to calculate and display the total size. This is calculated by adding the size of each layer for each manifest, making sure no layer size has been added more than once as a layer might be used in multiple manifests. 

This adds subcommand 'size' to the 'image' command, and displays the total size of the image in bytes for easy sorting, next to the image name.

### Screenshots

None