### PR TITLE
Added capability for deleting multiple tags

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"html/template"
 	"os"
+	"strings"
 
 	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
@@ -239,6 +240,14 @@ func deleteImage(c *cli.Context) error {
 					}
 				} else {
 					fmt.Printf("Only %d images are available\n", len(tags))
+				}
+			}
+		} else if strings.Contains(tag, ",") {
+			tags := strings.Split(tag, ",")
+			for _, value := range tags {
+				err = r.DeleteImageByTag(imgName, value)
+				if err != nil {
+					return cli.NewExitError(err.Error(), 1)
 				}
 			}
 		} else {


### PR DESCRIPTION
###Description
Added capability for deleting multiple tags. Tags are defined from command line by a comma seperator. Than it splits to an array and iterate over.

### Related Issue
#24 

### Changes proposed 

### Screenshots