### PR TITLE
Add semver sort option for tags listing and delete with -keep

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ $ nexus-cli image tags -name mlabouardy/nginx
 ```
 
 ```
+$ nexus-cli image tags -name mlabouardy/nginx -sort semver
+```
+
+```
 $ nexus-cli image info -name mlabouardy/nginx -tag 1.2.0
 ```
 
@@ -78,6 +82,10 @@ $ nexus-cli image delete -name mlabouardy/nginx -tag 1.2.0
 
 ```
 $ nexus-cli image delete -name mlabouardy/nginx -keep 4
+```
+
+```
+$ nexus-cli image delete -name mlabouardy/nginx -keep 4 -sort semver
 ```
 
 ## Tutorials

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func main() {
 						},
 						cli.StringFlag{
 							Name: "sort, s",
-							Usage: "Assume all tags are semver except latest",
+							Usage: "Sort tags by semantic version, assuming all tags are semver except latest.",
 						},
 					},
 					Action: func(c *cli.Context) error {
@@ -182,7 +182,7 @@ func listTagsByImage(c *cli.Context) error {
 	}
 	tags, err := r.ListTagsByImage(imgName)
 
-	compareStringNumber := getSortComparisonFunc(sort)
+	compareStringNumber := getSortComparisonStrategy(sort)
 	Compare(compareStringNumber).Sort(tags)
 
 	if err != nil {
@@ -242,7 +242,7 @@ func deleteImage(c *cli.Context) error {
 			} else {
 				tags, err := r.ListTagsByImage(imgName)
 
-				compareStringNumber := getSortComparisonFunc(sort)
+				compareStringNumber := getSortComparisonStrategy(sort)
 				Compare(compareStringNumber).Sort(tags)
 
 				if err != nil {
@@ -267,7 +267,7 @@ func deleteImage(c *cli.Context) error {
 	return nil
 }
 
-func getSortComparisonFunc(sort string) func(str1, str2 string) bool{
+func getSortComparisonStrategy(sort string) func(str1, str2 string) bool{
 	var compareStringNumber func(str1, str2 string) bool
 
 	if sort == "default" {

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/mlabouardy/nexus-cli/registry"
 	"github.com/urfave/cli"
+	"github.com/blang/semver"
 )
 
 const (
@@ -55,6 +56,10 @@ func main() {
 							Name:  "name, n",
 							Usage: "List tags by image name",
 						},
+						cli.StringFlag{
+							Name: "sort, s",
+							Usage: "Assume all tags are semver except latest",
+						},
 					},
 					Action: func(c *cli.Context) error {
 						return listTagsByImage(c)
@@ -87,6 +92,9 @@ func main() {
 						},
 						cli.StringFlag{
 							Name: "keep, k",
+						},
+						cli.StringFlag{
+							Name: "sort, s",
 						},
 					},
 					Action: func(c *cli.Context) error {
@@ -160,6 +168,11 @@ func listImages(c *cli.Context) error {
 
 func listTagsByImage(c *cli.Context) error {
 	var imgName = c.String("name")
+	var sort = c.String("sort")
+	if sort != "semver" {
+		sort = "default"
+	}
+
 	r, err := registry.NewRegistry()
 	if err != nil {
 		return cli.NewExitError(err.Error(), 1)
@@ -169,9 +182,7 @@ func listTagsByImage(c *cli.Context) error {
 	}
 	tags, err := r.ListTagsByImage(imgName)
 
-	compareStringNumber := func(str1, str2 string) bool {
-		return extractNumberFromString(str1) < extractNumberFromString(str2)
-	}
+	compareStringNumber := getSortComparisonFunc(sort)
 	Compare(compareStringNumber).Sort(tags)
 
 	if err != nil {
@@ -211,6 +222,11 @@ func deleteImage(c *cli.Context) error {
 	var imgName = c.String("name")
 	var tag = c.String("tag")
 	var keep = c.Int("keep")
+	var sort = c.String("sort")
+	if sort != "semver" {
+		sort = "default"
+	}
+
 	if imgName == "" {
 		fmt.Fprintf(c.App.Writer, "You should specify the image name\n")
 		cli.ShowSubcommandHelp(c)
@@ -225,10 +241,10 @@ func deleteImage(c *cli.Context) error {
 				cli.ShowSubcommandHelp(c)
 			} else {
 				tags, err := r.ListTagsByImage(imgName)
-				compareStringNumber := func(str1, str2 string) bool {
-					return extractNumberFromString(str1) < extractNumberFromString(str2)
-				}
+
+				compareStringNumber := getSortComparisonFunc(sort)
 				Compare(compareStringNumber).Sort(tags)
+
 				if err != nil {
 					return cli.NewExitError(err.Error(), 1)
 				}
@@ -249,4 +265,36 @@ func deleteImage(c *cli.Context) error {
 		}
 	}
 	return nil
+}
+
+func getSortComparisonFunc(sort string) func(str1, str2 string) bool{
+	var compareStringNumber func(str1, str2 string) bool
+
+	if sort == "default" {
+		compareStringNumber = func(str1, str2 string) bool {
+			return extractNumberFromString(str1) < extractNumberFromString(str2)
+		}
+	}
+
+	if sort == "semver" {
+		compareStringNumber = func(str1, str2 string) bool {
+			if str1 == "latest" {
+				return false
+			}
+			if str2 == "latest" {
+				return true
+			}
+			version1, err1 := semver.Make(str1)
+			if err1 != nil {
+			    fmt.Printf("Error parsing version1: %q\n", err1)
+			}
+			version2, err2 := semver.Make(str2)
+			if err2 != nil {
+			    fmt.Printf("Error parsing version2: %q\n", err2)
+			}
+			return version1.LT(version2)
+		}
+	}
+
+	return compareStringNumber
 }


### PR DESCRIPTION
### Description
Add semver sort option when listing tags as well as when using the keep flag when deleting. This ways it is possible to retain the last X versions. Used an exception for 'latest' tag.

The existing numeric sort breaks when you say you want to keep the last 5 versions:

`
1.0.1

1.0.11

1.1.0

2.0.0-alpha

2.0.0-beta

2.0.0

latest
`

As one can see, with the current numeric sort the order of 1.0.11 - 1.1.0 would be wrong wit numeric sort. In Semver it's 1.0.11 < 1.1.0. When using numeric sort it's 1.0.11 > 1.1.0 (wrong).

Hence I added an option for sorting -sort (default | semver)

### Related Issue
#5 

### Changes proposed 
Simply adding a good semver lib and an additional command line flag for tags listing and delete when using the keep option. Also updated the README.md.

### Screenshots

No screenshots, the description and the listing of the versions should be sufficient to explain the problem and its solution.